### PR TITLE
Insert missing include <vector>

### DIFF
--- a/sh/spherical_harmonics.h
+++ b/sh/spherical_harmonics.h
@@ -37,6 +37,7 @@
 #define SH_SPHERICAL_HARMONICS_H_
 
 #include <array>
+#include <vector>
 #include <functional>
 #include <memory>
 


### PR DESCRIPTION
There is a missing include in the spherical_harmonics.h. This request is to restore. Now it passes compilation with g++ -std=c++14