### PR TITLE
Fixing tests

### DIFF
--- a/third_party/gtest.BUILD
+++ b/third_party/gtest.BUILD
@@ -7,9 +7,8 @@ cc_library(
         exclude = ["googletest/src/gtest-all.cc"]
     ),
     hdrs = glob(["googletest/include/gtest/*.h"]),
-    includes = ["/",
-                "/include"
-    ],
+    includes = ["googletest/",
+                "googletest/include"],
     linkopts = ["-pthread"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Previous commit f3297f7b2c83404f4e6cbc2849680f64ee4bb409 (upgrade to bazel 3.4.1) broke tests. This fixes them.