### PR TITLE
Fix build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
   name = "eigen3",
-  url = "https://bitbucket.org/eigen/eigen/get/3.3.5.zip",
-  strip_prefix = "eigen-eigen-b3f3d4950030",
-  sha256 = "35fa84bc23114b9d37c4597745f8b4e03354a5077579fdba597019f595a602b6",
+  url = "https://gitlab.com/libeigen/eigen/-/archive/3.3.5/eigen-3.3.5.zip",
+  strip_prefix = "eigen-3.3.5",
+  sha256 = "0e7aeece6c8874146c2a4addc437eebdf1ec4026680270f00e76705c8186f0b5",
   build_file = "@//third_party:eigen3.BUILD",
 )
 

--- a/sh/BUILD
+++ b/sh/BUILD
@@ -25,6 +25,7 @@ cc_library(
     ],
     defines = select({
         ":windows": ["_USE_MATH_DEFINES",],
+        "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
https://bitbucket.org/eigen/eigen/get/3.3.5.zip is now completely a dead link. All eigen releases are moved to https://gitlab.com/libeigen/eigen/-/releases. This PR updates the link in WORKSPACE.

Additionally, bazel won't compile on non-Windows environments because there isn't a `//conditions:default` in the `select()` attribute. This has been added